### PR TITLE
Add support for custom content type determination

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,28 @@ Example:
   },
 ```
 
+### `getContentType`:
+
+Function that is executed to get the content type of the uploaded file.
+
+When no function is provided, the default content type of the file (`file.mime` is used).
+
+- Default value: `undefined`
+- Optional
+
+Example:
+
+```js
+  getContentType: (file) => {
+    switch ((file && file.ext || '').toLowerCase()) {
+      case '.avif':
+        return 'image/avif';
+      default:
+        return file.mime;
+    }
+  },
+```
+
 ## FAQ
 
 ### Common errors

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -171,7 +171,8 @@ const init = (providerConfig) => {
           await this.delete(file);
         }
         const fileAttributes = {
-          contentType: file.mime,
+          contentType:
+            typeof config.getContentType === 'function' ? config.getContentType(file) : file.mime,
           gzip: 'auto', // automatic gzip (based on contentType)
           metadata:
             typeof config.metadata === 'function'

--- a/test/lib/provider.js
+++ b/test/lib/provider.js
@@ -591,6 +591,49 @@ describe('/lib/provider.js', () => {
             assert.equal(assertionsCount, 6);
             mockRequire.stop('@google-cloud/storage');
           });
+
+          it('must save file with custom content type', async () => {
+            const saveExpectedArgs = [
+              'file buffer information',
+              {
+                contentType: 'application/x-test',
+                gzip: 'auto',
+                metadata: {
+                  contentDisposition: 'inline; filename="people coding.JPEG"',
+                },
+                public: true,
+              },
+            ];
+
+            const fileMock = createFileMock({ saveExpectedArgs });
+            const expectedFileNames = ['/tmp/strapi/4l0ngH45h.jpeg', '/tmp/strapi/4l0ngH45h.jpeg'];
+            const bucketMock = createBucketMock({ fileMock, expectedFileNames });
+            const Storage = class {
+              bucket(bucketName) {
+                assertionsCount += 1;
+                assert.equal(bucketName, 'any bucket');
+                return bucketMock;
+              }
+            };
+
+            mockRequire('@google-cloud/storage', { Storage });
+            const provider = mockRequire.reRequire('../../lib/provider');
+            const config = {
+              serviceAccount: {
+                project_id: '123',
+                client_email: 'my@email.org',
+                private_key: 'a random key',
+              },
+              bucketName: 'any bucket',
+              getContentType: (file) => {
+                return 'application/x-test';
+              },
+            };
+            const providerInstance = provider.init(config);
+            await providerInstance.upload(fileData);
+            assert.equal(assertionsCount, 6);
+            mockRequire.stop('@google-cloud/storage');
+          });
         });
 
         describe('when file exists in bucket', () => {


### PR DESCRIPTION
Can be useful for setting the content type of files that otherwise are assigned an `application/octet-stream`.

Signed-off-by: Frank3K <8014077+Frank3K@users.noreply.github.com>